### PR TITLE
Initialize unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+install:
+  - composer install

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,17 @@
   "require": {
     "php": ">=7.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^6.5"
+  },
   "autoload": {
-    "classmap": [
-      "src/Kharanenka/Helper"
-    ],
-    "psr-0": {
-      "Kharanenka\\Result\\": "src/"
+    "psr-4": {
+      "Kharanenka\\Helper\\": "src/Kharanenka/Helper/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Kharanenka\\Helper\\Tests\\": "tests/Kharanenka/Helper/"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="php-result-store Test Suite">
+            <directory suffix="Test.php">tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Kharanenka/Helper/ResultStoreTest.php
+++ b/tests/Kharanenka/Helper/ResultStoreTest.php
@@ -1,0 +1,96 @@
+<?php namespace Kharanenka\Helper\Tests;
+
+use Kharanenka\Helper\Result;
+use Kharanenka\Helper\ResultStore;
+use PHPUnit\Framework\TestCase;
+
+class ResultStoreTest extends TestCase
+{
+    public function testGetInstance()
+    {
+        $this->assertInstanceOf(ResultStore::class, ResultStore::getInstance());
+    }
+
+    public function testSetTrue()
+    {
+        $expected = ['key1' => 'value1', 'key2' => 'value2'];
+        $resultStore = Result::setTrue($expected);
+
+        $this->assertInstanceOf(ResultStore::class, $resultStore);
+        $this->assertSame($expected, Result::data());
+        $this->assertSame($expected, $resultStore->data());
+        $this->assertTrue($resultStore->status());
+    }
+
+    public function testSetFalse()
+    {
+        $expected = ['key1' => 'value1', 'key2' => 'value2'];
+        $resultStore = Result::setFalse($expected);
+
+        $this->assertInstanceOf(ResultStore::class, $resultStore);
+        $this->assertSame($expected, Result::data());
+        $this->assertSame($expected, $resultStore->data());
+        $this->assertFalse($resultStore->status());
+    }
+
+    public function testSetMessage()
+    {
+        $expected = 'this_is_a_message';
+        $resultStore = Result::setMessage($expected);
+
+        $this->assertInstanceOf(ResultStore::class, $resultStore);
+        $this->assertSame($expected, Result::message());
+        $this->assertSame($expected, $resultStore->message());
+    }
+
+    public function testSetCode()
+    {
+        $expected = 'this_is_error_code_value';
+        $resultStore = Result::setCode($expected);
+
+        $this->assertInstanceOf(ResultStore::class, $resultStore);
+        $this->assertSame($expected, Result::code());
+        $this->assertSame($expected, $resultStore->code());
+    }
+
+    public function testSetData()
+    {
+        $expected = ['key1' => 'value1', 'key2' => 'value2'];
+        $resultStore = Result::setData($expected);
+
+        $this->assertInstanceOf(ResultStore::class, $resultStore);
+        $this->assertSame($expected, Result::data());
+        $this->assertSame($expected, $resultStore->data());
+    }
+
+    public function testGet()
+    {
+        $data = ['key1' => 'value1', 'key2' => 'value2'];
+        $message = 'this_is_a_message';
+        $code = 'this_is_error_code_value';
+        $expected = [
+            'status'  => true,
+            'data'    => $data,
+            'message' => $message,
+            'code'    => $code,
+        ];
+        $resultStore = Result::setTrue($data);
+        $resultStore->setMessage($message)->setCode($code);
+
+        $this->assertSame($expected, $resultStore->get());
+        $this->assertSame($expected, Result::get());
+    }
+
+    public function testGetJSON()
+    {
+        $data = ['key1' => 'value1', 'key2' => 'value2'];
+        $message = 'this_is_a_message';
+        $code = 'this_is_error_code_value';
+        $expected = '{"status":true,"data":{"key1":"value1","key2":"value2"},"message":"this_is_a_message","code":"this_is_error_code_value"}';
+        $resultStore = Result::setTrue($data);
+        $resultStore->setMessage($message)->setCode($code);
+
+        $this->assertSame($expected, $resultStore->getJSON());
+        $this->assertSame($expected, Result::getJSON());
+    }
+}


### PR DESCRIPTION
# Changed log
- The `PSR-0` autoloading is deprecated. Using the `PSR-4` autoloading instead.
- Initialize the unit tests with PHPUnit.
- Add the Travis CI build integration.
The Travis CI build log is available [here](https://travis-ci.org/open-source-contributions/php-result-store/builds/564046053).